### PR TITLE
Enhance spherical Game of Life rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@
           </label>
           <label>
             <span>Résolution</span>
-            <strong id="resolutionValue" aria-live="polite">10</strong>
-            <input id="resolution" type="range" min="6" max="18" step="1" value="10" />
+            <strong id="resolutionValue" aria-live="polite">14</strong>
+            <input id="resolution" type="range" min="6" max="36" step="1" value="14" />
           </label>
           <label>
             <span>Zoom</span>
@@ -99,7 +99,7 @@
             <li><strong>Aléatoire</strong> : repeuple la sphère avec une configuration aléatoire.</li>
             <li><strong>Effacer</strong> : réinitialise toutes les cellules.</li>
             <li><strong>Vitesse</strong> : ajuste le temps entre deux générations automatiques.</li>
-            <li><strong>Résolution</strong> : modifie la finesse du maillage sphérique.</li>
+            <li><strong>Résolution</strong> : modifie la finesse du maillage sphérique jusqu'à 36 subdivisions par face.</li>
             <li><strong>Zoom</strong> : rapproche ou éloigne la caméra. Molette sur la sphère pour un ajustement fin.</li>
             <li><strong>Interaction directe</strong> : cliquez pour inverser l'état d'une cellule, faites glisser pour faire tourner.</li>
           </ul>


### PR DESCRIPTION
## Summary
- add curved cell outlines, base lighting, and highlight effects so the globe reads as a true sphere
- redesign alive and decaying cell styling with new scaling, colors, and glow to improve cell shapes
- extend the resolution slider to 36 subdivisions per face and document the expanded range in the help panel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc542052348331ae403780a5e3e1d6