### PR TITLE
fix: configure base path for github pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/Th-o/' : '/',
   plugins: [react()],
-});
+}));


### PR DESCRIPTION
## Summary
- configure the Vite base path so production builds target the GitHub Pages repository folder

## Testing
- not run (npm install blocked by registry permissions)

------
https://chatgpt.com/codex/tasks/task_e_68dcfa0bbb0c833182720fe59ccd5986