### PR TITLE
Use relative base path for production builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig(({ mode }) => ({
-  base: mode === 'production' ? '/Th-o/' : '/',
+  base: mode === 'production' ? './' : '/',
   plugins: [react()],
 }));


### PR DESCRIPTION
## Summary
- switch the Vite production base path to a relative URL so the app can load correctly when hosted from a subdirectory such as GitHub Pages

## Testing
- Not run (environment could not install npm packages)


------
https://chatgpt.com/codex/tasks/task_e_68dd3e5594c8833188f27e3127738d32